### PR TITLE
Add missing apply export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,4 @@ export * from './abs';
 export * from './sum';
 export * from './lib/parseISODuration';
 export * from './types';
+export * from './apply';


### PR DESCRIPTION
Should the `apply` function be exported too?

**Note**: I haven't actually tested this change and it's not covered by any tests.