### PR TITLE
Add toUnit

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ duration.toString({ years: 1, hours: 6 })
 
 // Conversion
 // ---------------------------------------------
+duration.toUnit({ minutes: 2 }, 'seconds') // 120
 duration.toMilliseconds({ seconds: 2 }) // 2000
 duration.toSeconds({ milliseconds: 2000 }) // 2
 duration.toMinutes({ hours: 1, seconds: 60 }) // 61

--- a/src/toUnit.test.ts
+++ b/src/toUnit.test.ts
@@ -1,5 +1,6 @@
 import {
 	toMilliseconds,
+	toUnit,
 	toSeconds,
 	toMinutes,
 	toHours,
@@ -36,6 +37,41 @@ describe('toMilliseconds()', () => {
 	test('throws errors for non-integer values', () => {
 		expect(() => toMilliseconds({ months: 1.5 })).toThrow();
 		expect(() => toMilliseconds({ months: 1 })).not.toThrow();
+	});
+});
+
+describe('toUnit()', () => {
+	test('converts objects', () => {
+		expect(toUnit({ milliseconds: 1 }, 'milliseconds')).toBe(1);
+		expect(toUnit({ seconds: 1 }, 'seconds')).toBe(1);
+		expect(toUnit({ minutes: 1 }, 'minutes')).toBe(1);
+		expect(toUnit({ hours: 1 }, 'hours')).toBe(1);
+		expect(toUnit({ days: 1 }, 'days')).toBe(1);
+		expect(toUnit({ weeks: 1 }, 'weeks')).toBe(1);
+		expect(toUnit({ months: 1 }, 'months')).toBe(1);
+		expect(toUnit({ years: 1 }, 'years')).toBe(1);
+	});
+
+	test('converts number of milliseconds', () => {
+		expect(toUnit(1, 'milliseconds')).toBe(1);
+		expect(toUnit(1 * 1000, 'seconds')).toBe(1);
+		expect(toUnit(1 * 1000 * 60, 'minutes')).toBe(1);
+		expect(toUnit(1 * 1000 * 60 * 60, 'hours')).toBe(1);
+		expect(toUnit(1 * 1000 * 60 * 60 * 24, 'days')).toBe(1);
+		expect(toUnit(1 * 1000 * 60 * 60 * 24 * 7, 'weeks')).toBe(1);
+		expect(toUnit((1 * 1000 * 60 * 60 * 24 * 365) / 12, 'months')).toBe(1);
+		expect(toUnit(1 * 1000 * 60 * 60 * 24 * 365, 'years')).toBe(1);
+	});
+
+	test('converts string durations', () => {
+		expect(toUnit('PT0.001S', 'milliseconds')).toBe(1);
+		expect(toUnit('PT1S', 'seconds')).toBe(1);
+		expect(toUnit('PT1M', 'minutes')).toBe(1);
+		expect(toUnit('PT1H', 'hours')).toBe(1);
+		expect(toUnit('P1D', 'days')).toBe(1);
+		expect(toUnit('P1W', 'weeks')).toBe(1);
+		expect(toUnit('P1M', 'months')).toBe(1);
+		expect(toUnit('P1Y', 'years')).toBe(1);
 	});
 });
 

--- a/src/toUnit.ts
+++ b/src/toUnit.ts
@@ -17,10 +17,19 @@ export const toMilliseconds = (duration: DurationInput): number => {
 	}, 0);
 };
 
+/**
+ * Convert the input value to the specificed unit.
+ * @example toUnit({ minutes: 2 }, 'seconds') // 120
+ */
+export const toUnit = (
+	duration: DurationInput,
+	unit: keyof typeof UNITS_MAP,
+): number => {
+	return toMilliseconds(duration) / UNITS_MAP[unit].milliseconds;
+};
+
 const createDurationConverter = (unit: keyof typeof UNITS_MAP) => {
-	return (duration: DurationInput): number => {
-		return toMilliseconds(duration) / UNITS_MAP[unit].milliseconds;
-	};
+	return (duration: DurationInput): number => toUnit(duration, unit);
 };
 
 /**


### PR DESCRIPTION
# Description

This PR adds a `toUnit` function for converting a duration to any unit:

```js
toUnit({ weeks: 3 }, 'days');
//=> 21
```

# Motivation

I'm working on this `DurationPicker` React component:

https://codesandbox.io/s/766jg

As you can see I've had to import `UNITS_MAP` and `toMilliseconds` in order to implement my own `toUnit` function. `toMilliseconds` isn't too bad, but `UNITS_MAP` doesn't feel like it should be part of the public API.

# Considerations

Would it be worth also exporting an array of the units in `index.js`? That would reduce the need for consumers to hardcode knowledge of these into their implementations. For example, the `smallestUnit` function in the `DurationPicker` example could be simplified to this:

```js
const smallestUnit = (duration, fallback = "seconds") => {
  const parsedDuration = parse(duration);
  return UNITS.reverse().find(unit => parsedDuration[unit] !== 0) ?? fallback;
};
```