### PR TITLE
Export `UNITS_LARGE_TO_SMALL`

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ duration.apply('2020-01-01T00:00:00.000Z', { years: 2 }).toISOString()
 
 duration.between('2022-01-01', '2020-01-01')
 // { years: -2 }
+
+
+// Meta
+// ---------------------------------------------
+duration.UNITS_LARGE_TO_SMALL
+// ['years', 'months', 'weeks', 'days', ...]
 ```
 
 ## Conventions

--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ duration.between('2022-01-01', '2020-01-01')
 
 // Meta
 // ---------------------------------------------
-duration.UNITS_LARGE_TO_SMALL
+duration.UNITS
+// A complete list of duration units, ordered from large to small:
 // ['years', 'months', 'weeks', 'days', ...]
 ```
 

--- a/src/between.ts
+++ b/src/between.ts
@@ -1,5 +1,5 @@
 import { Duration, DateInput } from './types';
-import { ZERO, UNITS } from './lib/units';
+import { ZERO, UNITS_META_LARGE_TO_SMALL } from './lib/units';
 
 /**
  * Gets the difference between two dates, expressed as a duration object.
@@ -12,7 +12,7 @@ export const between = (date1: DateInput, date2: DateInput): Duration => {
 	const b = new Date(date2);
 	const output: Duration = { ...ZERO };
 
-	UNITS.forEach(({ unit, dateGetter }) => {
+	UNITS_META_LARGE_TO_SMALL.forEach(({ unit, dateGetter }) => {
 		output[unit] = dateGetter(b) - dateGetter(a);
 	});
 

--- a/src/between.ts
+++ b/src/between.ts
@@ -1,5 +1,5 @@
 import { Duration, DateInput } from './types';
-import { ZERO, UNITS_META_LARGE_TO_SMALL } from './lib/units';
+import { ZERO, UNITS_META } from './lib/units';
 
 /**
  * Gets the difference between two dates, expressed as a duration object.
@@ -12,7 +12,7 @@ export const between = (date1: DateInput, date2: DateInput): Duration => {
 	const b = new Date(date2);
 	const output: Duration = { ...ZERO };
 
-	UNITS_META_LARGE_TO_SMALL.forEach(({ unit, dateGetter }) => {
+	UNITS_META.forEach(({ unit, dateGetter }) => {
 		output[unit] = dateGetter(b) - dateGetter(a);
 	});
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,4 +11,4 @@ export * from './sum';
 export * from './toString';
 export * from './toUnit';
 export * from './types';
-export { UNITS_LARGE_TO_SMALL } from './lib/units';
+export { UNITS as UNITS_LARGE_TO_SMALL } from './lib/units';

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,4 +11,4 @@ export * from './sum';
 export * from './toString';
 export * from './toUnit';
 export * from './types';
-export { UNITS as UNITS_LARGE_TO_SMALL } from './lib/units';
+export { UNITS } from './lib/units';

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,3 +11,4 @@ export * from './sum';
 export * from './toString';
 export * from './toUnit';
 export * from './types';
+export { UNITS_LARGE_TO_SMALL } from './lib/units';

--- a/src/lib/cleanDurationObject.ts
+++ b/src/lib/cleanDurationObject.ts
@@ -1,10 +1,10 @@
-import { UNIT_KEYS } from './units';
+import { UNITS_LARGE_TO_SMALL } from './units';
 import { Duration } from '../types';
 
 export const cleanDurationObject = (duration: Readonly<Duration>) => {
 	const output = { ...duration };
 
-	UNIT_KEYS.forEach(key => {
+	UNITS_LARGE_TO_SMALL.forEach(key => {
 		// Convert `-0` to `0`. Both values will evaluate as `true` here.
 		if (output[key] === 0) {
 			output[key] = 0;

--- a/src/lib/cleanDurationObject.ts
+++ b/src/lib/cleanDurationObject.ts
@@ -1,10 +1,10 @@
-import { UNITS_LARGE_TO_SMALL } from './units';
+import { UNITS } from './units';
 import { Duration } from '../types';
 
 export const cleanDurationObject = (duration: Readonly<Duration>) => {
 	const output = { ...duration };
 
-	UNITS_LARGE_TO_SMALL.forEach(key => {
+	UNITS.forEach(key => {
 		// Convert `-0` to `0`. Both values will evaluate as `true` here.
 		if (output[key] === 0) {
 			output[key] = 0;

--- a/src/lib/getUnitCount.ts
+++ b/src/lib/getUnitCount.ts
@@ -1,4 +1,4 @@
-import { UNITS_LARGE_TO_SMALL } from './units';
+import { UNITS } from './units';
 import { DurationInput } from '../types';
 import { parse } from '../parse';
 
@@ -6,7 +6,7 @@ export const getUnitCount = (duration: DurationInput): number => {
 	const parsed = { ...parse(duration) };
 	let count = 0;
 
-	UNITS_LARGE_TO_SMALL.forEach(unit => {
+	UNITS.forEach(unit => {
 		if (parsed[unit] !== 0) {
 			count++;
 		}

--- a/src/lib/getUnitCount.ts
+++ b/src/lib/getUnitCount.ts
@@ -1,4 +1,4 @@
-import { UNIT_KEYS } from './units';
+import { UNITS_LARGE_TO_SMALL } from './units';
 import { DurationInput } from '../types';
 import { parse } from '../parse';
 
@@ -6,7 +6,7 @@ export const getUnitCount = (duration: DurationInput): number => {
 	const parsed = { ...parse(duration) };
 	let count = 0;
 
-	UNIT_KEYS.forEach(unit => {
+	UNITS_LARGE_TO_SMALL.forEach(unit => {
 		if (parsed[unit] !== 0) {
 			count++;
 		}

--- a/src/lib/units.test.ts
+++ b/src/lib/units.test.ts
@@ -1,4 +1,4 @@
-import { UNITS_LARGE_TO_SMALL, UNITS_META_LARGE_TO_SMALL } from './units';
+import { UNITS, UNITS_META } from './units';
 
 const expectShallowImmutable = (arr: readonly unknown[]) => {
 	// Make a copy that is not "readonly" so TypeScript stops complaining.
@@ -7,19 +7,19 @@ const expectShallowImmutable = (arr: readonly unknown[]) => {
 	expect(() => { arrNonReadonly[0] = 1; }).toThrow();
 };
 
-describe('UNITS_LARGE_TO_SMALL', () => {
+describe('UNITS', () => {
 	test('is shallow immutable', () => {
-		expectShallowImmutable(UNITS_LARGE_TO_SMALL);
+		expectShallowImmutable(UNITS);
 	});
 });
 
-describe('UNITS_META_LARGE_TO_SMALL', () => {
+describe('UNITS_META', () => {
 	test('is shallow immutable', () => {
-		expectShallowImmutable(UNITS_META_LARGE_TO_SMALL);
+		expectShallowImmutable(UNITS_META);
 	});
 
 	test('every unit either has ISOCharacter information or a value to convert to for stringifying', () => {
-		expect(UNITS_META_LARGE_TO_SMALL.every(({
+		expect(UNITS_META.every(({
 			ISOCharacter,
 			ISOPrecision,
 			stringifyConvertTo,

--- a/src/lib/units.test.ts
+++ b/src/lib/units.test.ts
@@ -1,8 +1,25 @@
-import { UNITS } from './units';
+import { UNITS_LARGE_TO_SMALL, UNITS_META_LARGE_TO_SMALL } from './units';
 
-describe('UNITS', () => {
+const expectShallowImmutable = (arr: readonly unknown[]) => {
+	// Make a copy that is not "readonly" so TypeScript stops complaining.
+	const arrNonReadonly = arr as unknown[];
+	expect(() => { arrNonReadonly.reverse(); }).toThrow();
+	expect(() => { arrNonReadonly[0] = 1; }).toThrow();
+};
+
+describe('UNITS_LARGE_TO_SMALL', () => {
+	test('is shallow immutable', () => {
+		expectShallowImmutable(UNITS_LARGE_TO_SMALL);
+	});
+});
+
+describe('UNITS_META_LARGE_TO_SMALL', () => {
+	test('is shallow immutable', () => {
+		expectShallowImmutable(UNITS_META_LARGE_TO_SMALL);
+	});
+
 	test('every unit either has ISOCharacter information or a value to convert to for stringifying', () => {
-		expect(UNITS.every(({
+		expect(UNITS_META_LARGE_TO_SMALL.every(({
 			ISOCharacter,
 			ISOPrecision,
 			stringifyConvertTo,

--- a/src/lib/units.ts
+++ b/src/lib/units.ts
@@ -97,7 +97,7 @@ export const UNITS_META_MAP: { [key in UnitKey]: Unit } = UNITS_META_MAP_LITERAL
  * All the keys of the `Duration` type, ordered from largest
  * to smallest.
  */
-export const UNITS_LARGE_TO_SMALL = Object.freeze([
+export const UNITS = Object.freeze([
 	'years',
 	'months',
 	'weeks',
@@ -108,8 +108,8 @@ export const UNITS_LARGE_TO_SMALL = Object.freeze([
 	'milliseconds',
 ] as const);
 
-export const UNITS_META_LARGE_TO_SMALL = Object.freeze(
-	UNITS_LARGE_TO_SMALL.map(unit => ({
+export const UNITS_META = Object.freeze(
+	UNITS.map(unit => ({
 		...UNITS_META_MAP[unit],
 		unit,
 	})),

--- a/src/lib/units.ts
+++ b/src/lib/units.ts
@@ -22,7 +22,7 @@ export const ZERO = Object.freeze({
 
 export type UnitKey = keyof typeof ZERO;
 
-export const UNITS_MAP_LITERAL = {
+export const UNITS_META_MAP_LITERAL = {
 	years: {
 		milliseconds: MILLISECONDS_IN_A_YEAR,
 		months: 12,
@@ -91,9 +91,13 @@ interface Unit {
 // check when accessing an optional property that it knows is defined for the
 // specified unit (e.g. `UNITS_MAP_LITERAL.years.months`), whereas `UNITS_MAP`
 // needs the null check.
-export const UNITS_MAP: { [key in UnitKey]: Unit } = UNITS_MAP_LITERAL;
+export const UNITS_META_MAP: { [key in UnitKey]: Unit } = UNITS_META_MAP_LITERAL;
 
-export const UNIT_KEYS = [
+/**
+ * All the keys of the `Duration` type, ordered from largest
+ * to smallest.
+ */
+export const UNITS_LARGE_TO_SMALL = Object.freeze([
 	'years',
 	'months',
 	'weeks',
@@ -102,9 +106,11 @@ export const UNIT_KEYS = [
 	'minutes',
 	'seconds',
 	'milliseconds',
-] as const;
+] as const);
 
-export const UNITS = UNIT_KEYS.map(unit => ({
-	...UNITS_MAP[unit],
-	unit,
-}));
+export const UNITS_META_LARGE_TO_SMALL = Object.freeze(
+	UNITS_LARGE_TO_SMALL.map(unit => ({
+		...UNITS_META_MAP[unit],
+		unit,
+	})),
+);

--- a/src/lib/validate.ts
+++ b/src/lib/validate.ts
@@ -1,9 +1,9 @@
 import { Duration } from '../types';
-import { UNITS_LARGE_TO_SMALL } from './units';
+import { UNITS } from './units';
 
 export const validate = (duration: Readonly<Duration>) => {
 	(Object.keys(duration) as (keyof Duration)[]).forEach(unit => {
-		if (!UNITS_LARGE_TO_SMALL.includes(unit)) {
+		if (!UNITS.includes(unit)) {
 			throw new TypeError(`Unexpected property "${unit}" on Duration object.`);
 		}
 

--- a/src/lib/validate.ts
+++ b/src/lib/validate.ts
@@ -1,9 +1,9 @@
 import { Duration } from '../types';
-import { UNIT_KEYS } from './units';
+import { UNITS_LARGE_TO_SMALL } from './units';
 
 export const validate = (duration: Readonly<Duration>) => {
 	(Object.keys(duration) as (keyof Duration)[]).forEach(unit => {
-		if (!UNIT_KEYS.includes(unit)) {
+		if (!UNITS_LARGE_TO_SMALL.includes(unit)) {
 			throw new TypeError(`Unexpected property "${unit}" on Duration object.`);
 		}
 

--- a/src/negate.ts
+++ b/src/negate.ts
@@ -1,4 +1,4 @@
-import { UNITS_LARGE_TO_SMALL } from './lib/units';
+import { UNITS } from './lib/units';
 import { Duration, DurationInput } from './types';
 import { parse } from './parse';
 
@@ -12,7 +12,7 @@ import { parse } from './parse';
 export const negate = (duration: DurationInput): Duration => {
 	const output = { ...parse(duration) };
 
-	UNITS_LARGE_TO_SMALL.forEach(unit => {
+	UNITS.forEach(unit => {
 		output[unit] = output[unit] === 0
 			? 0
 			: -output[unit];

--- a/src/negate.ts
+++ b/src/negate.ts
@@ -1,4 +1,4 @@
-import { UNIT_KEYS } from './lib/units';
+import { UNITS_LARGE_TO_SMALL } from './lib/units';
 import { Duration, DurationInput } from './types';
 import { parse } from './parse';
 
@@ -12,7 +12,7 @@ import { parse } from './parse';
 export const negate = (duration: DurationInput): Duration => {
 	const output = { ...parse(duration) };
 
-	UNIT_KEYS.forEach(unit => {
+	UNITS_LARGE_TO_SMALL.forEach(unit => {
 		output[unit] = output[unit] === 0
 			? 0
 			: -output[unit];

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -1,4 +1,4 @@
-import { UNITS_MAP_LITERAL, ZERO, UnitKey } from './lib/units';
+import { UNITS_META_MAP_LITERAL, ZERO, UnitKey } from './lib/units';
 import { Duration, DurationInput, DateInput } from './types';
 import { between } from './between';
 import { apply } from './apply';
@@ -27,12 +27,12 @@ const createUnitsNormalizer = <T extends UnitKey>(
 
 const yearMonthNormalizer = createUnitsNormalizer(
 	['years', 'months'],
-	unit => UNITS_MAP_LITERAL[unit].months,
+	unit => UNITS_META_MAP_LITERAL[unit].months,
 );
 
 const dayAndTimeNormalizer = createUnitsNormalizer(
 	['days', 'hours', 'minutes', 'seconds', 'milliseconds'],
-	unit => UNITS_MAP_LITERAL[unit].milliseconds,
+	unit => UNITS_META_MAP_LITERAL[unit].milliseconds,
 );
 
 const baseNormalizer = (duration: DurationInput): Duration => {

--- a/src/sum.ts
+++ b/src/sum.ts
@@ -1,5 +1,5 @@
 import { Duration, DurationInput } from './types';
-import { UNIT_KEYS, ZERO } from './lib/units';
+import { UNITS_LARGE_TO_SMALL, ZERO } from './lib/units';
 import { parse } from './parse';
 
 /**
@@ -13,7 +13,7 @@ export const sum = (...durations: DurationInput[]): Duration => {
 	const output = { ...ZERO };
 
 	durations.map(parse).forEach(duration => {
-		UNIT_KEYS.forEach(key => {
+		UNITS_LARGE_TO_SMALL.forEach(key => {
 			output[key] += duration[key];
 		});
 	});

--- a/src/sum.ts
+++ b/src/sum.ts
@@ -1,5 +1,5 @@
 import { Duration, DurationInput } from './types';
-import { UNITS_LARGE_TO_SMALL, ZERO } from './lib/units';
+import { UNITS, ZERO } from './lib/units';
 import { parse } from './parse';
 
 /**
@@ -13,7 +13,7 @@ export const sum = (...durations: DurationInput[]): Duration => {
 	const output = { ...ZERO };
 
 	durations.map(parse).forEach(duration => {
-		UNITS_LARGE_TO_SMALL.forEach(key => {
+		UNITS.forEach(key => {
 			output[key] += duration[key];
 		});
 	});

--- a/src/toString.ts
+++ b/src/toString.ts
@@ -2,7 +2,7 @@ import { DurationInput } from './types';
 import { parse } from './parse';
 import { isZero } from './isZero';
 import { getUnitCount } from './lib/getUnitCount';
-import { UNITS, UNITS_MAP } from './lib/units';
+import { UNITS_META_LARGE_TO_SMALL, UNITS_META_MAP } from './lib/units';
 
 const joinComponents = (component: string[]) =>
 	component
@@ -39,19 +39,19 @@ export const toString = (duration: DurationInput): string => {
 	// Some units should be converted before stringifying.
 	// For example, weeks should not be mixed with other units, and milliseconds
 	// don't exist on ISO duration strings.
-	UNITS.forEach(({ unit: fromUnit, stringifyConvertTo: toUnit }) => {
+	UNITS_META_LARGE_TO_SMALL.forEach(({ unit: fromUnit, stringifyConvertTo: toUnit }) => {
 		if (toUnit == null) {
 			return;
 		}
 
-		const millisecondValue = parsed[fromUnit] * UNITS_MAP[fromUnit].milliseconds;
+		const millisecondValue = parsed[fromUnit] * UNITS_META_MAP[fromUnit].milliseconds;
 
-		parsed[toUnit] += millisecondValue / UNITS_MAP[toUnit].milliseconds;
+		parsed[toUnit] += millisecondValue / UNITS_META_MAP[toUnit].milliseconds;
 		parsed[fromUnit] = 0;
 	});
 
 	// Push each non-zero unit to its relevant array
-	UNITS.forEach(({ unit, ISOPrecision, ISOCharacter }) => {
+	UNITS_META_LARGE_TO_SMALL.forEach(({ unit, ISOPrecision, ISOCharacter }) => {
 		const value = parsed[unit];
 
 		if (ISOPrecision != null && value !== 0) {

--- a/src/toString.ts
+++ b/src/toString.ts
@@ -2,7 +2,7 @@ import { DurationInput } from './types';
 import { parse } from './parse';
 import { isZero } from './isZero';
 import { getUnitCount } from './lib/getUnitCount';
-import { UNITS_META_LARGE_TO_SMALL, UNITS_META_MAP } from './lib/units';
+import { UNITS_META, UNITS_META_MAP } from './lib/units';
 
 const joinComponents = (component: string[]) =>
 	component
@@ -39,7 +39,7 @@ export const toString = (duration: DurationInput): string => {
 	// Some units should be converted before stringifying.
 	// For example, weeks should not be mixed with other units, and milliseconds
 	// don't exist on ISO duration strings.
-	UNITS_META_LARGE_TO_SMALL.forEach(({ unit: fromUnit, stringifyConvertTo: toUnit }) => {
+	UNITS_META.forEach(({ unit: fromUnit, stringifyConvertTo: toUnit }) => {
 		if (toUnit == null) {
 			return;
 		}
@@ -51,7 +51,7 @@ export const toString = (duration: DurationInput): string => {
 	});
 
 	// Push each non-zero unit to its relevant array
-	UNITS_META_LARGE_TO_SMALL.forEach(({ unit, ISOPrecision, ISOCharacter }) => {
+	UNITS_META.forEach(({ unit, ISOPrecision, ISOCharacter }) => {
 		const value = parsed[unit];
 
 		if (ISOPrecision != null && value !== 0) {

--- a/src/toUnit.ts
+++ b/src/toUnit.ts
@@ -1,6 +1,6 @@
 import { DurationInput } from './types';
 import { parse } from './parse';
-import { UNITS, UNITS_MAP } from './lib/units';
+import { UNITS_META_LARGE_TO_SMALL, UNITS_META_MAP } from './lib/units';
 
 /**
  * Convert the input value to milliseconds represented by a duration object.
@@ -12,7 +12,7 @@ import { UNITS, UNITS_MAP } from './lib/units';
 export const toMilliseconds = (duration: DurationInput): number => {
 	const parsed = parse(duration);
 
-	return UNITS.reduce((total, { unit, milliseconds }) => {
+	return UNITS_META_LARGE_TO_SMALL.reduce((total, { unit, milliseconds }) => {
 		return total + (parsed[unit] * milliseconds);
 	}, 0);
 };
@@ -23,12 +23,12 @@ export const toMilliseconds = (duration: DurationInput): number => {
  */
 export const toUnit = (
 	duration: DurationInput,
-	unit: keyof typeof UNITS_MAP,
+	unit: keyof typeof UNITS_META_MAP,
 ): number => {
-	return toMilliseconds(duration) / UNITS_MAP[unit].milliseconds;
+	return toMilliseconds(duration) / UNITS_META_MAP[unit].milliseconds;
 };
 
-const createDurationConverter = (unit: keyof typeof UNITS_MAP) => {
+const createDurationConverter = (unit: keyof typeof UNITS_META_MAP) => {
 	return (duration: DurationInput): number => toUnit(duration, unit);
 };
 

--- a/src/toUnit.ts
+++ b/src/toUnit.ts
@@ -1,6 +1,6 @@
 import { DurationInput } from './types';
 import { parse } from './parse';
-import { UNITS_META_LARGE_TO_SMALL, UNITS_META_MAP } from './lib/units';
+import { UNITS_META, UNITS_META_MAP } from './lib/units';
 
 /**
  * Convert the input value to milliseconds represented by a duration object.
@@ -12,7 +12,7 @@ import { UNITS_META_LARGE_TO_SMALL, UNITS_META_MAP } from './lib/units';
 export const toMilliseconds = (duration: DurationInput): number => {
 	const parsed = parse(duration);
 
-	return UNITS_META_LARGE_TO_SMALL.reduce((total, { unit, milliseconds }) => {
+	return UNITS_META.reduce((total, { unit, milliseconds }) => {
 		return total + (parsed[unit] * milliseconds);
 	}, 0);
 };


### PR DESCRIPTION
@haydn this what you have in mind?

The changes are based on the "Considerations" part of this PR:
https://github.com/dlevs/duration-fns/pull/11

I renamed some variables to be more explicit about the ordering since `UNITS_LARGE_TO_SMALL` (previously `UNIT_KEYS`) is part of the public API now.

Also stuck another `Object.freeze()` in there to prevent nasty mutation surprises when calling `UNITS_LARGE_TO_SMALL.reverse()`.