### PR TITLE
Add Flow types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1552,6 +1552,12 @@
         "delayed-stream": "~1.0.0"
       }
     },
+    "commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "dev": true
+    },
     "component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
@@ -2538,6 +2544,22 @@
       "integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
       "dev": true
     },
+    "flowgen": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/flowgen/-/flowgen-1.13.0.tgz",
+      "integrity": "sha512-xgdbeWfhY5yayQ3PUTaPn9a0tPK21m5SEJSFZDZf0A0TuoLKYVXU3fhhAN9pokjDcb0E0FGh7EO3t3YNf/iXTw==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/highlight": "^7.10.4",
+        "commander": "^6.1.0",
+        "lodash": "^4.17.20",
+        "prettier": "^2.1.1",
+        "shelljs": "^0.8.4",
+        "typescript": "^4.0.2",
+        "typescript-compiler": "^1.4.1-2"
+      }
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -2949,6 +2971,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
       "dev": true
     },
     "ip-regex": {
@@ -4553,6 +4581,12 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
     },
+    "prettier": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
+      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+      "dev": true
+    },
     "pretty-format": {
       "version": "26.6.2",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
@@ -4645,6 +4679,15 @@
       "requires": {
         "find-up": "^2.0.0",
         "read-pkg": "^2.0.0"
+      }
+    },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.1.6"
       }
     },
     "regex-not": {
@@ -5072,6 +5115,17 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
+    },
+    "shelljs": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
+      "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
     },
     "shellwords": {
       "version": "0.1.1",
@@ -5729,6 +5783,12 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
       "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+      "dev": true
+    },
+    "typescript-compiler": {
+      "version": "1.4.1-2",
+      "resolved": "https://registry.npmjs.org/typescript-compiler/-/typescript-compiler-1.4.1-2.tgz",
+      "integrity": "sha1-uk99si2RU0oZKdkACdzhYety/T8=",
       "dev": true
     },
     "union-value": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint 'src/**/*.+(ts|js)'",
     "test": "TZ=UTC jest",
     "prebuild": "npm run test && npm run lint && npm run clean",
-    "flowgen": "for file in $(find ./dist -name *.d.ts -type f); do flowgen ${file} -o ${file/.d.ts/.flow.js}; done;",
+    "flowgen": "for file in $(find dist -type f -name \"*.d.ts\"); do sh -c \"flowgen $file -o ${file%.*.*}.flow.js\"; done;",
     "build": "tsc && npm run flowgen",
     "prepublish": "npm run build"
   },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "lint": "eslint 'src/**/*.+(ts|js)'",
     "test": "TZ=UTC jest",
     "prebuild": "npm run test && npm run lint && npm run clean",
-    "build": "tsc",
+    "flowgen": "for file in $(find ./dist -name *.d.ts -type f); do flowgen ${file} -o ${file/.d.ts/.flow.js}; done;",
+    "build": "tsc && npm run flowgen",
     "prepublish": "npm run build"
   },
   "author": "Daniel Levett <dlevett@hotmail.co.uk>",
@@ -28,6 +29,7 @@
     "eslint": "7.18.0",
     "eslint-config-airbnb-base": "14.2.1",
     "eslint-plugin-import": "2.22.1",
+    "flowgen": "^1.13.0",
     "jest": "26.6.3",
     "rimraf": "3.0.2",
     "ts-jest": "26.5.0",


### PR DESCRIPTION
# Description

Adds `*.flow.js` Flow type declarations to the `dist` folder during the build process. This is done using [flowgen](https://github.com/joarwilk/flowgen) to automatically convert TypeScript declaration files to Flow declarations.

# Motivation

People use Flow. This is an easy way to also provide Flow types. It's pretty reliable for a simple libraries with minimal dependencies like this. (I've been using it for my own [graph-fns](https://github.com/haydn/graph-fns/blob/main/package.json#L21) library recently without trouble.)