### PR TITLE
Make `toString()` output a single negative sign for all-negative durations

### DIFF
--- a/src/lib/checkAllUnitsNegative.test.ts
+++ b/src/lib/checkAllUnitsNegative.test.ts
@@ -30,5 +30,10 @@ describe('checkAllUnitsNegative()', () => {
 			isAllNegative: false,
 			maybeAbsDuration: { ...ZERO, hours: -6, minutes: -2, seconds: 1 },
 		});
+
+		expect(checkAllUnitsNegative(ZERO)).toEqual({
+			isAllNegative: false,
+			maybeAbsDuration: ZERO,
+		});
 	});
 });

--- a/src/lib/checkAllUnitsNegative.test.ts
+++ b/src/lib/checkAllUnitsNegative.test.ts
@@ -1,0 +1,34 @@
+import { checkAllUnitsNegative } from './checkAllUnitsNegative';
+import { ZERO } from './units';
+
+describe('checkAllUnitsNegative()', () => {
+	test('correctly identifies and flips "all negative" values', () => {
+		expect(checkAllUnitsNegative({
+			hours: -6,
+			minutes: -2,
+		})).toEqual({
+			isAllNegative: true,
+			maybeAbsDuration: { ...ZERO, hours: 6, minutes: 2 },
+		});
+
+		expect(checkAllUnitsNegative({
+			hours: -6,
+			minutes: -2,
+			seconds: 0,
+		})).toEqual({
+			isAllNegative: true,
+			maybeAbsDuration: { ...ZERO, hours: 6, minutes: 2 },
+		});
+	});
+
+	test('correctly identifies and leaves alone non "all negative" values', () => {
+		expect(checkAllUnitsNegative({
+			hours: -6,
+			minutes: -2,
+			seconds: 1,
+		})).toEqual({
+			isAllNegative: false,
+			maybeAbsDuration: { ...ZERO, hours: -6, minutes: -2, seconds: 1 },
+		});
+	});
+});

--- a/src/lib/checkAllUnitsNegative.ts
+++ b/src/lib/checkAllUnitsNegative.ts
@@ -1,0 +1,39 @@
+import type { Duration, DurationInput } from '../types';
+import { negate } from '../negate';
+import { parse } from '../parse';
+import { UNITS } from './units';
+
+/**
+ * Get an indication of whether all of the non-zero units in a duration are
+ * negative. If they are, return a positive representation of the duration,
+ * with `isAllNegative` set to `true`.
+ */
+export const checkAllUnitsNegative = (duration: DurationInput): {
+	isAllNegative: boolean
+	maybeAbsDuration: Duration
+} => {
+	const parsed = parse(duration);
+	let hasPositive = false;
+	let hasNegative = false;
+
+	UNITS.forEach((unit) => {
+		const value = parsed[unit];
+		if (value < 0) {
+			hasNegative = true;
+		} else if (value > 0) {
+			hasPositive = true;
+		}
+	});
+
+	if (hasNegative && !hasPositive) {
+		return {
+			isAllNegative: true,
+			maybeAbsDuration: negate(parsed),
+		};
+	}
+
+	return {
+		isAllNegative: false,
+		maybeAbsDuration: parsed,
+	};
+};

--- a/src/toString.test.ts
+++ b/src/toString.test.ts
@@ -38,9 +38,9 @@ describe('toString()', () => {
 	// Some parsers don't support mixed positive / negative. We try to use a
 	// single negative sign where possible, like `-P2Y10D`.
 	//
-	// To ensure compatibility, call `normalize()` with a reference date before
-	// calling `toString()`. This will ensure that the output is not a mix of
-	// positive and negative values.
+	// Ideally there would be a way to guarantee that there will be no mixed
+	// units in the result. TODO: Implement and document this. See:
+	// https://github.com/dlevs/duration-fns/pull/25#issuecomment-1037260764
 	test('handles mixed positive and negative values', () => {
 		expect(toString({ years: -2, days: 10 })).toBe('P-2Y10D');
 		expect(toString({ years: 1, seconds: -6 })).toBe('P1YT-6S');

--- a/src/toString.test.ts
+++ b/src/toString.test.ts
@@ -28,10 +28,23 @@ describe('toString()', () => {
 		expect(toString('P700D')).toBe('P700D');
 	});
 
-	test('handles negative values', () => {
-		expect(toString({ years: -2 })).toBe('P-2Y');
+	test('handles negative values by outputting a single negative sign', () => {
+		expect(toString({ years: -2 })).toBe('-P2Y');
+		expect(toString({ years: -2, days: -10 })).toBe('-P2Y10D');
+		expect(toString({ years: -1, hours: -2, seconds: -6 })).toBe('-P1YT2H6S');
+		expect(toString({ years: -0 })).toBe('P0D');
+	});
+
+	// Some parsers don't support mixed positive / negative. We try to use a
+	// single negative sign where possible, like `-P2Y10D`.
+	//
+	// To ensure compatibility, call `normalize()` with a reference date before
+	// calling `toString()`. This will ensure that the output is not a mix of
+	// positive and negative values.
+	test('handles mixed positive and negative values', () => {
 		expect(toString({ years: -2, days: 10 })).toBe('P-2Y10D');
 		expect(toString({ years: 1, seconds: -6 })).toBe('P1YT-6S');
+		expect(toString({ years: -1, hours: 2, seconds: -6 })).toBe('P-1YT2H-6S');
 	});
 
 	test('represents decimal seconds', () => {


### PR DESCRIPTION
Avoids "P-1DT-1H". Instead, outputs "-P1DT1H".

Addresses: https://github.com/dlevs/duration-fns/issues/22
Made the behaviour match this, which sounds reasonable: https://github.com/moment/moment/issues/3960#issuecomment-303517484