### PR TITLE
fix: Publish source files

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist/**/*",
+    "dist",
     "src"
   ],
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist/**/*"
+    "dist/**/*",
+    "src"
   ],
   "scripts": {
     "clean": "rimraf dist",


### PR DESCRIPTION
- Fixes https://github.com/dlevs/duration-fns/issues/28

### Problem
Source maps are included in the package distribution (since `sourceMap` is set to true in the tsconfig `compilerOptions`) but the source files themselves are not. This means the `sources` field in the source map files is invalid, and Webpack complains by throwing up a bunch of "Failed to parse source map from ..." errors.

### Fix
The `src` files are now included in the published package, which means the paths in the sourcemap files are now valid

Similar fix in the mswjs library: https://github.com/mswjs/interceptors/pull/204